### PR TITLE
feat: add payment methods to footer

### DIFF
--- a/assets/mastercard.svg
+++ b/assets/mastercard.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="32" viewBox="0 0 50 32">
+  <rect width="50" height="32" fill="#fff"/>
+  <circle cx="20" cy="16" r="12" fill="#EB001B"/>
+  <circle cx="30" cy="16" r="12" fill="#F79E1B" fill-opacity="0.8"/>
+</svg>

--- a/assets/paypal.svg
+++ b/assets/paypal.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="32" viewBox="0 0 50 32">
+  <rect width="50" height="32" fill="#003087"/>
+  <text x="25" y="20" font-family="Arial" font-size="16" fill="#fff" text-anchor="middle">PayPal</text>
+</svg>

--- a/assets/visa.svg
+++ b/assets/visa.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="32" viewBox="0 0 50 32">
+  <rect width="50" height="32" fill="#1A1F71"/>
+  <text x="25" y="22" font-family="Arial" font-size="18" fill="#fff" text-anchor="middle">VISA</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -150,10 +150,17 @@
       </div>
     </section>
   </main>
-  <footer class="site-footer container">
-    <span>© <span id="year"></span> SENS</span>
-    <a href="#" data-i18n="footer.privacy">الخصوصية</a>
-    <a href="#" data-i18n="footer.terms">الشروط</a>
-  </footer>
+    <footer class="site-footer container">
+      <span>© <span id="year"></span> SENS</span>
+      <div class="payment-methods">
+        <img src="assets/visa.svg" alt="Visa" width="50" height="32">
+        <img src="assets/mastercard.svg" alt="Mastercard" width="50" height="32">
+        <img src="assets/paypal.svg" alt="PayPal" width="50" height="32">
+      </div>
+      <div class="footer-links">
+        <a href="#" data-i18n="footer.privacy">الخصوصية</a>
+        <a href="#" data-i18n="footer.terms">الشروط</a>
+      </div>
+    </footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,10 @@ a{color:inherit}img{max-width:100%;height:auto;display:block}
 .contact-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:start}
 .contact-form{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:16px;display:grid;gap:8px}
 .contact-form input,.contact-form textarea{background:#0e1118;color:var(--fg);border:1px solid var(--border);border-radius:8px;padding:10px}
-.site-footer{display:flex;gap:16px;justify-content:space-between;border-top:1px solid var(--border);margin-top:30px}
+.site-footer{display:flex;gap:16px;justify-content:space-between;align-items:center;border-top:1px solid var(--border);margin-top:30px}
+.site-footer .footer-links{display:flex;gap:16px}
+.payment-methods{display:flex;gap:8px;align-items:center}
+.payment-methods img{height:24px}
 @media (max-width: 960px){
   .hero{grid-template-columns:1fr}
   .features .grid{grid-template-columns:1fr 1fr}


### PR DESCRIPTION
## Summary
- show Visa, Mastercard and PayPal icons in footer
- style footer and payment method icons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fb54ffb8832998f68210ae01b1cd